### PR TITLE
Update patch for AmmonomiconController.OpenInternal()

### DIFF
--- a/Code/HelperTools.cs
+++ b/Code/HelperTools.cs
@@ -5,6 +5,9 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using UnityEngine;
+using MonoMod.Cil;
+using Mono.Cecil.Cil;
+using System.Reflection;
 
 namespace AmmonomiconAPI
 {
@@ -81,6 +84,12 @@ namespace AmmonomiconAPI
             string key = $"#AMMONOMICON_AUTO_DB_STRING_{++_AutoStringCounter}";
             ETGMod.Databases.Strings.Items.AddComplex(key, s);
             return key;
+        }
+
+        /// <summary>Convenience method for calling an internal / private static function with an ILCursor</summary>
+        internal static void CallPrivate(this ILCursor cursor, Type t, string name)
+        {
+            cursor.Emit(OpCodes.Call, t.GetMethod(name, BindingFlags.Static | BindingFlags.NonPublic));
         }
     }
 }


### PR DESCRIPTION
...so it doesn't completely overwrite the basegame method (broke the "Ammonomicon Opens To Targeted Item" patch in Gunfig).

![rotato-botato](https://github.com/user-attachments/assets/c08208da-6bac-4a5d-95bb-466b021779d8)
